### PR TITLE
feat: connect new attendee api

### DIFF
--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -35,8 +35,15 @@ export type CreateSessionRequest = {
   sessionName: string;
 };
 
+export type UpdateSessionsRequest = {
+  sessions: {
+    id: number;
+    name: string;
+  }[];
+};
+
 export type DeleteSessionRequest = {
-  sessionId: number;
+  sessionIds: number[];
 };
 
 export type SessionWithoutId = Omit<Session, "id">;
@@ -117,9 +124,11 @@ export const createSession = async (request: CreateSessionRequest) => {
 };
 
 export const deleteSession = async (request: DeleteSessionRequest) => {
-  return axios.delete(`/api/session`, {
-    params: request,
-  });
+  return axios.post(`/api/session/delete`, request);
+};
+
+export const updateSessions = async (request: UpdateSessionsRequest) => {
+  return axios.put("/api/session", request);
 };
 
 export const useSessions = (courseId: number) => {

--- a/src/components/attendees/AttendeeAttendanceItem.tsx
+++ b/src/components/attendees/AttendeeAttendanceItem.tsx
@@ -1,0 +1,53 @@
+import dateFormat from "dateformat";
+
+import { AttendanceInfo } from "../../api/attendee";
+import AttendanceChipSelection from "../sessions/AttendanceChipSelection";
+import { TableRow, TableItem } from "../table/Table";
+
+interface AttendeeAttendanceItemProps
+  extends React.HTMLAttributes<HTMLTableRowElement> {
+  attendance: AttendanceInfo;
+  onAttendanceStatusChange?: (status: boolean) => void;
+  isEditing: boolean;
+  to?: string;
+}
+
+const AttendeeAttendanceItem = ({
+  attendance,
+  isEditing,
+  onAttendanceStatusChange,
+  to,
+  ...props
+}: AttendeeAttendanceItemProps) => {
+  return (
+    <TableRow {...props}>
+      <TableItem noBorders to={to}>
+        {dateFormat(attendance.attendanceTime, "yyyy-mm-dd")}
+      </TableItem>
+      <TableItem
+        noBorders
+        style={{
+          width: "24rem",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+        to={to}
+      >
+        {attendance.sessionName}
+      </TableItem>
+      <TableItem noBorders to={to}>
+        <AttendanceChipSelection
+          attendance={attendance.attendanceStatus}
+          onAttendanceChange={onAttendanceStatusChange}
+          isEditing={isEditing}
+        />
+      </TableItem>
+      <TableItem noBorders to={to}>
+        {dateFormat(attendance.attendanceTime, "HH:MM:ss")}
+      </TableItem>
+    </TableRow>
+  );
+};
+
+export default AttendeeAttendanceItem;

--- a/src/components/attendees/AttendeesItem.tsx
+++ b/src/components/attendees/AttendeesItem.tsx
@@ -91,6 +91,7 @@ function AttendeesItem({
                 onAttendeeChange({ ...attendee, note: e.target.value });
               }
             }}
+            style={{ width: "100%" }}
           />
         ) : (
           <div

--- a/src/components/sessions/AttendanceChipSelection.tsx
+++ b/src/components/sessions/AttendanceChipSelection.tsx
@@ -1,0 +1,50 @@
+import styled from "styled-components";
+
+import AttendanceChip from "./AttendanceChip";
+
+export interface AttendanceChipSelectionProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  isEditing?: boolean;
+  attendance: boolean;
+  onAttendanceChange?: (attendance: boolean) => void;
+}
+
+const AttendanceChipSelection = ({
+  isEditing,
+  attendance,
+  onAttendanceChange,
+  ...props
+}: AttendanceChipSelectionProps) => {
+  return (
+    <AttendanceChipContainer {...props}>
+      {(isEditing || attendance) && (
+        <AttendanceChip
+          type={"attendance"}
+          active={attendance}
+          clickable
+          onClick={() => {
+            onAttendanceChange?.(true);
+          }}
+        />
+      )}
+      {(isEditing || !attendance) && (
+        <AttendanceChip
+          type={"absence"}
+          active={!attendance}
+          clickable
+          onClick={() => {
+            onAttendanceChange?.(false);
+          }}
+        />
+      )}
+    </AttendanceChipContainer>
+  );
+};
+
+const AttendanceChipContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.8rem;
+`;
+
+export default AttendanceChipSelection;

--- a/src/components/sessions/SessionAttendeeItem.tsx
+++ b/src/components/sessions/SessionAttendeeItem.tsx
@@ -1,0 +1,56 @@
+import dateFormat from "dateformat";
+import React from "react";
+
+import { TableItem } from "../table/Table.tsx";
+
+import AttendanceChipSelection from "./AttendanceChipSelection.tsx";
+
+interface SessionAttendeeItemProps
+  extends React.HTMLAttributes<HTMLTableRowElement> {
+  isEditing: boolean;
+  to?: string;
+  name: string;
+  attendanceStatus: boolean;
+  attendanceTime: Date;
+  onAttendanceStatusChange?: (status: boolean) => void;
+}
+
+function SessionAttendeeItem({
+  isEditing,
+  to,
+  name,
+  attendanceStatus,
+  attendanceTime,
+  onAttendanceStatusChange,
+  ...props
+}: SessionAttendeeItemProps) {
+  return (
+    <tr {...props}>
+      <TableItem
+        style={{
+          width: "24rem",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        }}
+        to={to}
+      >
+        {name}
+      </TableItem>
+      <TableItem to={to}>
+        <AttendanceChipSelection
+          attendance={attendanceStatus}
+          onAttendanceChange={onAttendanceStatusChange}
+          isEditing={isEditing}
+        />
+      </TableItem>
+      <TableItem to={to}>
+        {!isEditing && attendanceStatus === true
+          ? dateFormat(attendanceTime, "HH:MM:ss")
+          : "--:--:--"}
+      </TableItem>
+    </tr>
+  );
+}
+
+export default SessionAttendeeItem;

--- a/src/pages/main/Attendees/Attendee.tsx
+++ b/src/pages/main/Attendees/Attendee.tsx
@@ -1,6 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import dateFormat from "dateformat";
-import React, { useState } from "react";
+import { useState } from "react";
 import styled from "styled-components";
 
 import {
@@ -14,15 +13,14 @@ import {
   useAttendee,
 } from "../../../api/attendee.ts";
 import Alert from "../../../components/Alert.tsx";
+import AttendeeAttendanceItem from "../../../components/attendees/AttendeeAttendanceItem.tsx";
 import { PrimaryButton, TertiaryButton } from "../../../components/Button.tsx";
 import InfoBar from "../../../components/InfoBar.tsx";
-import AttendanceChip from "../../../components/sessions/AttendanceChip.tsx";
 import {
   Table,
   TableBody,
   TableHead,
   TableHeadItem,
-  TableItem,
   TableRow,
 } from "../../../components/table/Table.tsx";
 import TableControl from "../../../components/table/TableControl.tsx";
@@ -187,66 +185,22 @@ function Attendee() {
               ? Object.values(tempAttendances)
               : attendeeData?.attendanceInfo ?? []
             ).map((attendance, index) => (
-              <TableRow key={index}>
-                <TableItem noBorders>
-                  {dateFormat(attendance.attendanceTime, "yyyy-mm-dd")}
-                </TableItem>
-                <TableItem
-                  noBorders
-                  style={{
-                    width: "24rem",
-                    whiteSpace: "nowrap",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                  }}
-                >
-                  {attendance.sessionName}
-                </TableItem>
-                <TableItem noBorders>
-                  {isEditing ? (
-                    <AttendanceChipContainer>
-                      <AttendanceChip
-                        type={"attendance"}
-                        active={attendance.attendanceStatus}
-                        clickable
-                        onClick={() => {
-                          setTempAttendances({
-                            ...tempAttendances,
-                            [attendance.attendanceId]: {
-                              ...attendance,
-                              attendanceStatus: true,
-                            },
-                          });
-                        }}
-                      />
-                      <AttendanceChip
-                        type={"absence"}
-                        active={!attendance.attendanceStatus}
-                        clickable
-                        onClick={() => {
-                          setTempAttendances({
-                            ...tempAttendances,
-                            [attendance.attendanceId]: {
-                              ...attendance,
-                              attendanceStatus: false,
-                            },
-                          });
-                        }}
-                      />
-                    </AttendanceChipContainer>
-                  ) : (
-                    <AttendanceChip
-                      type={
-                        attendance.attendanceStatus ? "attendance" : "absence"
-                      }
-                      active
-                    />
-                  )}
-                </TableItem>
-                <TableItem noBorders>
-                  {dateFormat(attendance.attendanceTime, "HH:MM:ss")}
-                </TableItem>
-              </TableRow>
+              <AttendeeAttendanceItem
+                key={index}
+                attendance={attendance}
+                isEditing={isEditing}
+                onAttendanceStatusChange={(status) => {
+                  setTempAttendances({
+                    ...tempAttendances,
+                    [attendance.attendanceId]: {
+                      ...tempAttendances[attendance.attendanceId],
+                      attendanceStatus: status,
+                    },
+                  });
+                }}
+                // TODO: Link to session detail page
+                to={isEditing ? undefined : `/courses/${courseId}/sessions/1`}
+              />
             ))}
           </TableBody>
         </Table>
@@ -269,12 +223,6 @@ const ContentContainer = styled.div`
   margin-left: 6.2rem;
   margin-right: auto;
   margin-bottom: 5rem;
-`;
-
-const AttendanceChipContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 0.8rem;
 `;
 
 export default Attendee;

--- a/src/pages/main/Attendees/Attendee.tsx
+++ b/src/pages/main/Attendees/Attendee.tsx
@@ -184,24 +184,36 @@ function Attendee() {
             {(isEditing
               ? Object.values(tempAttendances)
               : attendeeData?.attendanceInfo ?? []
-            ).map((attendance, index) => (
-              <AttendeeAttendanceItem
-                key={index}
-                attendance={attendance}
-                isEditing={isEditing}
-                onAttendanceStatusChange={(status) => {
-                  setTempAttendances({
-                    ...tempAttendances,
-                    [attendance.attendanceId]: {
-                      ...tempAttendances[attendance.attendanceId],
-                      attendanceStatus: status,
-                    },
-                  });
-                }}
-                // TODO: Link to session detail page
-                to={isEditing ? undefined : `/courses/${courseId}/sessions/1`}
-              />
-            ))}
+            )
+              .sort((a, b) => {
+                if (option === "earliest") {
+                  return (
+                    a.attendanceTime.getTime() - b.attendanceTime.getTime()
+                  );
+                } else {
+                  return (
+                    b.attendanceTime.getTime() - a.attendanceTime.getTime()
+                  );
+                }
+              })
+              .map((attendance, index) => (
+                <AttendeeAttendanceItem
+                  key={index}
+                  attendance={attendance}
+                  isEditing={isEditing}
+                  onAttendanceStatusChange={(status) => {
+                    setTempAttendances({
+                      ...tempAttendances,
+                      [attendance.attendanceId]: {
+                        ...tempAttendances[attendance.attendanceId],
+                        attendanceStatus: status,
+                      },
+                    });
+                  }}
+                  // TODO: Link to session detail page
+                  to={isEditing ? undefined : `/courses/${courseId}/sessions/1`}
+                />
+              ))}
           </TableBody>
         </Table>
       </ContentContainer>

--- a/src/pages/main/Attendees/Attendees.tsx
+++ b/src/pages/main/Attendees/Attendees.tsx
@@ -9,6 +9,7 @@ import {
   updateAttendee,
   useAttendees,
 } from "../../../api/attendee.ts";
+import Alert from "../../../components/Alert.tsx";
 import AlertModal from "../../../components/AlertModal.tsx";
 import AttendeesItem from "../../../components/attendees/AttendeesItem.tsx";
 import {
@@ -43,6 +44,7 @@ function Attendees() {
       queryClient.invalidateQueries({ queryKey: ["attendees", classId] });
     },
   });
+
   const { mutate: updateAttendees } = useMutation({
     mutationFn: updateAttendee,
     mutationKey: ["updateAttendee"],
@@ -51,11 +53,16 @@ function Attendees() {
       // cleanup
       setTempAttendees(null);
       setEditing(false);
+      setHasNamesakeError(false);
+      setCheckedState({});
     },
     onError: () => {
       // TODO: show error message
+      setHasNamesakeError(true);
     },
   });
+
+  const [hasNamesakeError, setHasNamesakeError] = useState(false);
 
   const {
     checkedState,
@@ -113,7 +120,6 @@ function Attendees() {
           originalAttendeesMap.get(attendee.id)?.name !== attendee.name ||
           originalAttendeesMap.get(attendee.id)?.note !== attendee.note
       );
-      console.log(changedAttendees);
 
       // send changed attendees to server
       updateAttendees({
@@ -164,6 +170,12 @@ function Attendees() {
           )}
         </HeaderContainer>
         <ContentContainer>
+          {hasNamesakeError && (
+            <Alert type="warning" style={{ marginBottom: "1.2rem" }}>
+              There are attendees with the same name and note. Please modify
+              them without duplication.
+            </Alert>
+          )}
           <Table>
             <TableHead>
               <tr>
@@ -178,7 +190,7 @@ function Attendees() {
                 )}
                 <TableHeadItem
                   style={{
-                    width: "20rem",
+                    width: "18rem",
                     border: "none",
                   }}
                 >
@@ -186,15 +198,15 @@ function Attendees() {
                 </TableHeadItem>
                 <TableHeadItem
                   style={{
-                    width: "20rem",
+                    width: "26.5rem",
                     border: "none",
                   }}
                 >
-                  Notes
+                  Note
                 </TableHeadItem>
                 <TableHeadItem
                   style={{
-                    width: "14rem",
+                    width: "17rem",
                     border: "none",
                   }}
                 >
@@ -280,7 +292,7 @@ const HeaderContainer = styled.div`
   justify-content: space-between;
   margin-left: 6.2rem;
   margin-right: auto;
-  margin-bottom: 1.6rem;
+  margin-bottom: 1.3rem;
 
   h5 {
     ${theme.typography.h5};

--- a/src/pages/main/session/SessionDetail.tsx
+++ b/src/pages/main/session/SessionDetail.tsx
@@ -1,7 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import dateFormat from "dateformat";
 import { useState } from "react";
-import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 
 import {
@@ -15,24 +14,24 @@ import {
 } from "../../../api/session";
 import { PrimaryButton, TertiaryButton } from "../../../components/Button.tsx";
 import InfoBar from "../../../components/InfoBar.tsx";
-import AttendanceChip from "../../../components/sessions/AttendanceChip";
+import SessionAttendeeItem from "../../../components/sessions/SessionAttendeeItem.tsx";
 import {
   Table,
   TableBody,
   TableHead,
   TableHeadItem,
-  TableItem,
 } from "../../../components/table/Table.tsx";
 import TableControl from "../../../components/table/TableControl.tsx";
 import TitleBar from "../../../components/TitleBar";
+import { useClassId, useSessionId } from "../../../hooks/urlParse.tsx";
 
 function SessionDetail() {
   const [filter, setFilter] = useState<string>("all");
   const [isEditing, setIsEditing] = useState(false);
   const [tempAttendees, setTempAttendees] = useState<SessionAttendee[]>([]);
 
-  const location = useLocation();
-  const sessionId = parseInt(location.pathname.split("/")[4], 10);
+  const classId = useClassId();
+  const sessionId = useSessionId();
   const { data: session } = useSession(sessionId);
   const { data: sessionAttendees } = useSessionAttendees(sessionId);
 
@@ -42,9 +41,14 @@ function SessionDetail() {
     mutationKey: ["updateAttendances"],
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+
+      // 임시로 tempAttendees에 저장된 데이터로 덮어씌워서 fetch가 끝나기 전 이전 데이터가 잠시 보이는 것을 방지
+      queryClient.setQueryData(["sessionAttendees", sessionId], tempAttendees);
       queryClient.invalidateQueries({
         queryKey: ["sessionAttendees", sessionId],
       });
+
+      setIsEditing(false);
     },
   });
 
@@ -63,7 +67,6 @@ function SessionDetail() {
               updateAttendees({
                 updateAttendances: updateData,
               });
-              setIsEditing(false);
             }}
           >
             Save
@@ -119,63 +122,27 @@ function SessionDetail() {
                 }
               })
               .map(({ attendee, index }) => (
-                <tr>
-                  <TableItem
-                    style={{
-                      width: "24rem",
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                    }}
-                  >
-                    {attendee.attendee.name}
-                  </TableItem>
-                  <TableItem>
-                    <AttendanceChipContainer>
-                      {(isEditing || attendee.attendanceStatus) && (
-                        <AttendanceChip
-                          type="attendance"
-                          active={attendee.attendanceStatus}
-                          clickable={isEditing}
-                          onClick={() => {
-                            if (isEditing) {
-                              const newTempAttendees = [...tempAttendees];
-                              newTempAttendees[index] = {
-                                ...newTempAttendees[index],
-                                attendanceStatus:
-                                  !newTempAttendees[index].attendanceStatus,
-                              };
-                              setTempAttendees(newTempAttendees);
-                            }
-                          }}
-                        />
-                      )}
-                      {(isEditing || !attendee.attendanceStatus) && (
-                        <AttendanceChip
-                          type="absence"
-                          active={!attendee.attendanceStatus}
-                          clickable={isEditing}
-                          onClick={() => {
-                            if (isEditing) {
-                              const newTempAttendees = [...tempAttendees];
-                              newTempAttendees[index] = {
-                                ...newTempAttendees[index],
-                                attendanceStatus:
-                                  !newTempAttendees[index].attendanceStatus,
-                              };
-                              setTempAttendees(newTempAttendees);
-                            }
-                          }}
-                        />
-                      )}
-                    </AttendanceChipContainer>
-                  </TableItem>
-                  <TableItem>
-                    {sessionAttendees?.[index]?.attendanceStatus === true
-                      ? dateFormat(attendee?.attendanceTime, "HH:MM:ss")
-                      : "--:--:--"}
-                  </TableItem>
-                </tr>
+                <SessionAttendeeItem
+                  key={index}
+                  name={attendee.attendee.name}
+                  attendanceStatus={attendee.attendanceStatus}
+                  attendanceTime={attendee.attendanceTime}
+                  isEditing={isEditing}
+                  onAttendanceStatusChange={(status) => {
+                    const newTempAttendees = [...tempAttendees];
+                    newTempAttendees[index] = {
+                      ...attendee,
+                      attendanceStatus: status,
+                    };
+                    setTempAttendees(newTempAttendees);
+                  }}
+                  // TODO: 링크 잇기
+                  // to={
+                  //   isEditing
+                  //     ? undefined
+                  //     : `/class/${classId}/attendee/${attendee.attendee.id}`
+                  // }
+                />
               ))}
           </TableBody>
         </Table>
@@ -198,13 +165,6 @@ const ContentContainer = styled.div`
   margin-left: 6.2rem;
   margin-right: auto;
   margin-bottom: 5rem;
-`;
-
-const AttendanceChipContainer = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 1rem;
 `;
 
 export default SessionDetail;

--- a/src/pages/main/session/Sessions.tsx
+++ b/src/pages/main/session/Sessions.tsx
@@ -216,8 +216,15 @@ function Sessions() {
               </tr>
             </TableHead>
             <TableBody>
-              {(editing ? Object.values(tempSessions) : sessions ?? []).map(
-                (session) => (
+              {(editing ? Object.values(tempSessions) : sessions ?? [])
+                .sort((a, b) => {
+                  if (option === "earliest") {
+                    return a.date.getTime() - b.date.getTime();
+                  } else {
+                    return b.date.getTime() - a.date.getTime();
+                  }
+                })
+                .map((session) => (
                   <SessionItem
                     isChecked={checkedState[session.id]}
                     onCheckboxChange={() => handleCheckboxChange(session.id)}
@@ -236,8 +243,7 @@ function Sessions() {
                     }
                     session={session}
                   />
-                )
-              )}
+                ))}
             </TableBody>
           </Table>
         </Content>


### PR DESCRIPTION
## 변경점
1. session 수정 api 구현 및 연결
2. session 삭제 api 연결
3. session / session detail에서 수정 시 동명이인 발생하면 `Alert` 띄우도록 함
4. Attendee Detail / Session Detail 페이지의 Table Row를 Component로 분리
4.1. 페이지 코드 줄이고, table row 눌렀을 때 서로 오갈 수 있는 링크를 넣기 위한 준비 목적이었음
4.2. 그러나 링크를 넣기 위한 id 정보를 backend에서 주지 않고 있기에 수정 요청이 필요
5. AttendeeChipSelection 컴포넌트 제작
5.1. 출석 / 결석 중 하나 고르는 Chip Input 컴포넌트
5.2. 2회 재사용되는데, 간단하지만 구현을 위한 코드가 길어서 분리하였음
6. Attendee Detail Save 로직을 변경
6.1. Save를 위해 두 번의 api call이 필요한데, api call 실패 시 save가 완료되면 안 되므로 (에러를 띄우고 계속 edit mode여야 함) `Promise.all` 이용하여 mutation을 하나로 묶음
6.2. 한편으로는 api call을 두 번 하는 것이 이상하다는 생각도 듦. 둘 중 하나가 실패하고 하나가 성공하면 어떻게 처리해야 하지?
7. Earliest / Latest 정렬 옵션 구현